### PR TITLE
Create method to update account balance for custom accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ Wrapper Functions :
     - [`getHoldings(accounts /*Array[String]*/)`]()
     - [`getHistories(accounts /*Array[String]*/, startDate /*String*/, endDate /*String*/, intervalType /*String*/, types /*Array[String]*/)`]()
     - [`updateBalance(accountName /*String*/, newBalance /*Number*/)`]()
+    - [`addHolding(accountName, /*String*/ ticker, /*String*/ description, /*String*/ quantity, /*Number*/ price, /*Number*/ costBasis /*Number*/)`]()
+    - [`updateHolding(accounts, /*Array[String]*/ holdingTicker, /*String*/ quantity, /*Number*/ price, /*Number*/ costBasis /*Number*/)`]()
+    - [`updateInvestmentCashBalance(accountName, /*String*/ newBalance /*Number*/)`]()
+    - [`getHoldingByTicker(accounts, /*Array[String]*/ holdingTicker /*String*/)`]()
     - [`getAccountByName(accountName /*String*/)`]()
+
+`updateBalance` method works with all custom accounts other than Custom Stock Options and Manual Investment Holdings.
+`addHolding`, `updateHolding`, and `updateInvestmentCashBalance` methods work with Manual Investment Holdings asset type
 
 ## Installation
 ```bash

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Wrapper Functions :
     - [`getTransactions(accounts /*Array[String]*/, startDate /*String*/, endDate /*String*/)`]()
     - [`getHoldings(accounts /*Array[String]*/)`]()
     - [`getHistories(accounts /*Array[String]*/, startDate /*String*/, endDate /*String*/, intervalType /*String*/, types /*Array[String]*/)`]()
+    - [`updateBalance(accountName /*String*/, newBalance /*Number*/)`]()
+    - [`getAccountByName(accountName /*String*/)`]()
 
 ## Installation
 ```bash

--- a/personalcapital/personalcapital.js
+++ b/personalcapital/personalcapital.js
@@ -92,7 +92,8 @@ class PersonalCapital {
         getaccounts: '/api/newaccount/getAccounts2',
         gettransactions: '/api/transaction/getUserTransactions',
         getholdings: '/api/invest/getHoldings',
-        gethistories: '/api/account/getHistories'
+        gethistories: '/api/account/getHistories',
+        updatebalance: '/api/newaccount/updateAccount'
       }
     });
   }
@@ -166,7 +167,7 @@ class PersonalCapital {
         const resp = await r1.questionAsync('Enter 2FA code : ');
         await this.__2FAAuth__(resp);
       }
-      await this.__passwordAuth__('cathorsebatterystaple1');
+      await this.__passwordAuth__(passwd);
     }
   }
 
@@ -207,6 +208,38 @@ class PersonalCapital {
       accounts, startDate, endDate, intervalType, types));
     return res;
   }
+
+  // accountName must match name on account exactly
+  async updateBalance(accountName /*String*/, newBalance /*Number*/) {
+    const account = await this.getAccountByName(accountName);
+    const updateData = {
+      ...account,
+      isTransferPending: false,
+      isTransferEligible: true,
+      ownershipType: null,
+      employerMatchLimitType: "dollar",
+      requestSource: "USER",
+      balance: newBalance,
+      currentBalance: newBalance,
+      availableBalance: newBalance
+    };
+    const res = await this.endpoint("updatebalance", updateData);
+    return res;
+  }
+
+  async getAccountByName(accountName /*String*/) {
+    const accounts = await this.getAccounts();
+
+    const selectedAccount = accounts.filter(account => {
+      return account.name === accountName;
+    });
+    if (!selectedAccount || selectedAccount.length === 0) {
+      throw `Account ${accountName} not found!`;
+    }
+
+    return selectedAccount[0];
+  }
+
 }
 
 module.exports = {PersonalCapital, TwoFactorMode};


### PR DESCRIPTION
Created a method that can be used to update the balance of custom accounts.
Account name in Personal Capital and new balance are accepted as parameters.

This can be used to write programs that scrape data from sources not supported by Personal Capital, and update the balance in Personal Capital.